### PR TITLE
Fixed spelling mistake

### DIFF
--- a/common/src/main/resources/assets/walkietalkie/lang/de_de.json
+++ b/common/src/main/resources/assets/walkietalkie/lang/de_de.json
@@ -16,7 +16,7 @@
   "advancement.walkietalkie.root.description": "Entdecken Sie die Macht der Kommunikation mit dem Walkie-Talkie.",
 
   "advancement.walkietalkie.wooden_walkietalkie.title": "Grundlegende Kommunikation",
-  "advancement.walkietalkie.wooden_walkietalkie.description": "Holz Walkie-Talkie erhalten, um über kurze Distanzen kommunizieren kannst.",
+  "advancement.walkietalkie.wooden_walkietalkie.description": "Holz Walkie-Talkie erhalten, um über kurze Distanzen kommunizieren zu können.",
 
   "advancement.walkietalkie.stone_walkietalkie.title": "Verbesserte Kommunikation",
   "advancement.walkietalkie.stone_walkietalkie.description": "Stein Walkie-Talkies erhalten, das eine größere Kommunikationsreichweite ermöglicht.",


### PR DESCRIPTION
Accidently used present tense instead of subjunctive in the last part of the sentence